### PR TITLE
Fix addon crash on german client after 1.1 update

### DIFF
--- a/HolyStats.lua
+++ b/HolyStats.lua
@@ -171,7 +171,7 @@ end
 
 function getTalentRank(talent)
 	local talents = {
-		['Priest'] = {
+		['PRIEST'] = {
 			['Spiritual Healing'] = {2,15},
 			['Improved Healing'] = {2,10},
 			['Improved Renew'] = {2,2},
@@ -180,7 +180,7 @@ function getTalentRank(talent)
 			['Meditation'] = {1,8},
 			['Improved Prayer of Healing'] = {2,12}
 		},
-		['Paladin'] = {
+		['PALADIN'] = {
 			['Healing Light'] = {1,5},
 			['Illumination'] = {1,9},
 			['Holy Power'] = {1,13}

--- a/HolyStats.lua
+++ b/HolyStats.lua
@@ -3,7 +3,7 @@ local regen
 local delay
 local isSpellsFrame = false
 local pauseUpdate = false
-local class = UnitClass("player");
+local _, class = UnitClass("player");
 
 local frame = CreateFrame("FRAME")
 frame:RegisterEvent("ADDON_LOADED")

--- a/SpellsFrame.lua
+++ b/SpellsFrame.lua
@@ -1,6 +1,6 @@
 local cache = {}
 local healingSpells = {
-	['Priest'] = {
+	['PRIEST'] = {
 		['Lesser Heal'] = {
 			['Rank 1'] = {
 				org = {
@@ -396,7 +396,7 @@ local healingSpells = {
 			},
 		}
 	},
-	['Paladin'] = {
+	['PALADIN'] = {
 		['Flash of Light'] = {
 			['Rank 1'] = {
 				org = {
@@ -578,7 +578,7 @@ local healingSpells = {
 
 local sortBy = 'eff'
 local sortOrder = 1
-local class = UnitClass("player")
+local _, class = UnitClass("player")
 
 function SpellsFrame_OnLoad(self)
 	SpellsFrameBG:SetVertexColor(0.2, 0.2, 0.2)


### PR DESCRIPTION
The 1.1 update added a bug which causes the the addon to crash on the german client for priests.
This is because
UnitClass("player")
returns a localized string and the keys for classes are in english.

This fix updates the above line to use the second argument which is the "englishClass"
localizedClass, englishClass, classIndex = UnitClass("unit");

This bug only occurs for priests. Paladin is the same word in german.
