### PR TITLE
Update HolyStats.lua

### DIFF
--- a/HolyStats.lua
+++ b/HolyStats.lua
@@ -76,7 +76,7 @@ function HolyStats_update()
 	local full = maxmana/regen
 	local fullin = (maxmana-mana)/regen
 	local percent = 100*mana/maxmana
-	local crit = GetSpellCritChance() + (getTalentRank('Holy Specialization') or 0) + (getTalentRank('Holy Power') or 0)
+	local crit = GetSpellCritChance() + getTalentRank('Holy Specialization')
 
 	local itemBonus = 0
 	local itemRegen = 0


### PR DESCRIPTION
It seems that the Holy Power talent (https://classic.wowhead.com/spell=25829/holy-power) is already included in the GetSpellCritChance() method which is weird because it says "Increases the critical effect chance of your **Holy** Spells by 1%"

So I wrote an addon that logged and parsed the combat log. Here are the results (Sample size is not huge but I think its enough)

https://imgur.com/a/KV7bdX5

"Crit" is from GetSpellCritChance()
"Real" is (Number of Crits / Number of Noncrits)
"n" is sample size
"Diff" is the difference